### PR TITLE
Fix invalid BepInEx link that was leading people to download prerelease versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Trombone Champ Custom Chart Loader
 This project is licensed under the terms of the MIT license.
 
 ## Installation
-If your game isn't modded with BepinEx, DO THAT FIRST! Simply go to the [latest BepinEx release](https://github.com/BepInEx/BepInEx/releases) and extract BepinEx_x64_VERSION.zip directly into your game's folder, then run the game once to install BepinEx properly.
+If your game isn't modded with BepinEx, DO THAT FIRST! Simply go to the [latest BepinEx release](https://github.com/BepInEx/BepInEx/releases/latest) and extract BepinEx_x64_VERSION.zip directly into your game's folder, then run the game once to install BepinEx properly.
 
 Next, download `TrombLoader.dll` and put it into your game's `BepInEx/plugins` folder.
 


### PR DESCRIPTION
- Minor change to the Readme to ensure people are getting the right version of BepInEx