### PR TITLE
Added .mp4 loading support

### DIFF
--- a/Class Patches/BGControllerPatch.cs
+++ b/Class Patches/BGControllerPatch.cs
@@ -18,7 +18,13 @@ namespace TrombLoader.Class_Patches
 
             var songPath = Path.Combine(Globals.GetCustomSongsPath(), trackReference);
             var spritePath = Path.Combine(songPath, "bg.png");
+            var videoPath = Path.Combine(songPath, "bg.mp4");
             var backgroundPath = Path.Combine(songPath, "bg.trombackground"); // comically large file extension
+
+            // Possible backgrounds in order of priority:
+            // AssetBundle (.trombackground)
+            // Video (.mp4)
+            // Sprite (.png)
 
             Plugin.LogDebug("Trying to load custom background!!");
             //string trackReference = GlobalVariables.data_trackrefs[GlobalVariables.chosen_track_index];
@@ -28,18 +34,27 @@ namespace TrombLoader.Class_Patches
                 {
                     // do nothing
                     // probably change the above to have a proper confirmation it worked at some point
-                    __instance.doBGEffect(BGEffect);
                 }
                 else
                 {
                     __instance.DisableBackground();
                     Plugin.LogDebug("Disabled Backgrounds...");
-                    Plugin.LogDebug($"Trying to load Custom sprite from path: {spritePath}");
-                    var sprite = ImageHelper.LoadSpriteFromFile(spritePath);
-                    __instance.SetBasicBackground(sprite);
 
-                    __instance.doBGEffect(BGEffect);
+                    if (File.Exists(videoPath))
+                    {
+                        Plugin.LogDebug($"Trying to load Custom Video from path: {spritePath}");
+
+                        __instance.SetVideoBackground(videoPath);
+                    }
+                    else
+                    {
+                        Plugin.LogDebug($"Trying to load Custom sprite from path: {spritePath}");
+                        var sprite = ImageHelper.LoadSpriteFromFile(spritePath);
+                        __instance.SetBasicBackground(sprite);
+                    }
                 }
+
+                __instance.doBGEffect(BGEffect);
             }
         }
     }

--- a/Class Patches/GameControllerStartPatch.cs
+++ b/Class Patches/GameControllerStartPatch.cs
@@ -8,6 +8,7 @@ using System.Security.Permissions;
 using TrombLoader.Data;
 using TrombLoader.Helpers;
 using UnityEngine;
+using UnityEngine.Video;
 using UnityEngine.Events;
 using UnityEngine.PostProcessing;
 
@@ -207,6 +208,16 @@ namespace TrombLoader.Class_Patches
 						var invoker = gameObject.AddComponent<TromboneEventInvoker>();
 						invoker.InitializeInvoker(__instance, managers);
 						UnityEngine.Object.DontDestroyOnLoad(invoker);
+
+						foreach (var videoPlayer in gameObject.GetComponentsInChildren<VideoPlayer>())
+                        {
+							if (videoPlayer.url != null && videoPlayer.url.Contains("SERIALIZED_OUTSIDE_BUNDLE"))
+							{
+								var videoName = videoPlayer.url.Replace("SERIALIZED_OUTSIDE_BUNDLE/", "");
+								var clipURL = Path.Combine(Globals.GetCustomSongsPath(), customTrackReference, videoName);
+								videoPlayer.url = clipURL;
+							}
+						}
 					}
 				}
 			}

--- a/Class Patches/TromboneChampExtensions.cs
+++ b/Class Patches/TromboneChampExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.Video;
 
 namespace TrombLoader.Class_Patches
 {
@@ -37,6 +38,20 @@ namespace TrombLoader.Class_Patches
                 Plugin.LogError("Failed to set up custom BG");
             }
 
+        }
+
+        public static void SetVideoBackground(this BGController bgController, string url)
+        {
+            var planeObject = bgController.bgplane.transform.GetChild(0);
+            var videoPlayer = planeObject.GetComponent<VideoPlayer>() ?? planeObject.gameObject.AddComponent<VideoPlayer>();
+
+            videoPlayer.url = url;
+            videoPlayer.isLooping = true;
+            videoPlayer.playOnAwake = true;
+
+            videoPlayer.renderMode = VideoRenderMode.CameraNearPlane;
+
+            DisableLayer(bgController.bgplane, true);
         }
 
         public static void DisableLayer(GameObject obj, bool enable = false)

--- a/TrombLoader.csproj
+++ b/TrombLoader.csproj
@@ -74,5 +74,8 @@
    <Reference Include="UnityEngine.IMGUIModule">
      <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
    </Reference>
+   <Reference Include="UnityEngine.VideoModule">
+     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
+   </Reference>
  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Added the ability to load `video.mp4` from songs
   - This takes priority over images, but not over AssetBundles
- Added a fix to properly serialize video files from AssetBundles
   - This won't fully work until the [Unity project](https://github.com/legoandmars/TrombLoaderBackgroundProject/) is updated, which will be done within the next day