### PR TITLE
Add puppet/tromboner loading support

### DIFF
--- a/Class Patches/PuppetControllerPatch.cs
+++ b/Class Patches/PuppetControllerPatch.cs
@@ -1,0 +1,91 @@
+﻿using System.IO;
+using HarmonyLib;
+using TrombLoader.Helpers;
+using UnityEngine;
+
+namespace TrombLoader.Class_Patches
+{
+    [HarmonyPatch(typeof(GameController))]
+    [HarmonyPatch("startSong")]
+    public class GameControllerStartSongPatch
+    {
+        static void Postfix(GameController __instance)
+        {
+            foreach(var tromboner in Globals.Tromboners)
+            {
+                if(tromboner != null) LeanTween.scaleY(tromboner.gameObject, 1f, 0.5f).setEaseOutBounce().setDelay(2f);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameController))]
+    [HarmonyPatch("startSong")]
+    public class GameControllerStartDancePatch
+    {
+        static void Postfix(GameController __instance)
+        {
+            var tempTempo = __instance.tempo;
+            if (tempTempo > 90f) tempTempo *= 0.5f;
+            if (__instance.beatspermeasure == 1) tempTempo *= 0.6666667f;
+
+            foreach (var tromboner in Globals.Tromboners)
+            {
+                if (tromboner != null) tromboner.controller.startPuppetBob(tempTempo);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(HumanPuppetController))]
+    [HarmonyPatch("doPuppetControl")]
+    public class HumanPuppetControllerPuppetControlPatch
+    {
+        static void Postfix(HumanPuppetController __instance, float vp)
+        {
+            if (__instance.transform.parent.name == "PlayerModelHolder")
+            {
+                foreach (var tromboner in Globals.Tromboners)
+                {
+                    if (tromboner != null)
+                    {
+                        tromboner.controller.doPuppetControl(vp);
+                        tromboner.controller.vibrato = __instance.vibrato;
+                    }
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameController))]
+    [HarmonyPatch("setPuppetBreath")]
+    public class GameControllerPuppetBreathPatch
+    {
+        static void Postfix(GameController __instance, bool hasbreath)
+        {
+            foreach (var tromboner in Globals.Tromboners)
+            {
+                if (tromboner != null)
+                {
+                    tromboner.controller.outofbreath = hasbreath;
+                    tromboner.controller.applyFaceTex();
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(GameController))]
+    [HarmonyPatch("setPuppetShake")]
+    public class GameControllerPuppetShakePatch
+    {
+        static void Postfix(GameController __instance, bool shake)
+        {
+            foreach (var tromboner in Globals.Tromboners)
+            {
+                if (tromboner != null)
+                {
+                    tromboner.controller.shaking = shake;
+                    tromboner.controller.applyFaceTex();
+                }
+            }
+        }
+    }
+}

--- a/Data/Reparent.cs
+++ b/Data/Reparent.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+namespace TrombLoader.Data
+{
+    public class Reparent : MonoBehaviour
+    {
+        public int instanceID;
+
+        public void LateUpdate()
+        {
+            foreach(Transform child in GameObject.Find("BGCameraObj").transform.GetChild(1).GetChild(0))
+            {
+                if(child.name == "_" + instanceID)
+                {
+                    transform.parent = child.GetChild(0);
+                    enabled = false;
+                }
+            }
+        }
+    }
+}

--- a/Data/Tromboner.cs
+++ b/Data/Tromboner.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace TrombLoader.Data
+{
+    public class Tromboner
+    {
+        public GameObject gameObject;
+        public Transform transform;
+        public HumanPuppetController controller;
+
+        public Tromboner(GameObject _gameObject)
+        {
+            gameObject = _gameObject;
+            transform = _gameObject.transform;
+            controller = _gameObject.GetComponent<HumanPuppetController>();
+        }
+    }
+}

--- a/Data/TrombonerPlaceholder.cs
+++ b/Data/TrombonerPlaceholder.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using UnityEngine;
+
+namespace TrombLoader.Data
+{
+    public class TrombonerPlaceholder : MonoBehaviour
+    {
+        public TrombonerType TrombonerType = TrombonerType.DoNotOverride;
+        public TromboneSkin TromboneSkin = TromboneSkin.DoNotOverride;
+
+        [HideInInspector, SerializeField]
+        public int InstanceID = 0;
+    }
+
+    [Serializable]
+    public enum TrombonerType
+    {
+        [InspectorName("Do Not Override (Default)")]
+        DoNotOverride = -1,
+        [InspectorName("Appaloosa")]
+        Female1 = 0,
+        [InspectorName("Beezerly")]
+        Female2 = 1,
+        [InspectorName("Kaizyle II")]
+        Female3 = 2,
+        [InspectorName("Trixiebell")]
+        Female4 = 3,
+        [InspectorName("Meldor")]
+        Male1 = 4,
+        [InspectorName("Jermajesty")]
+        Male2 = 5,
+        [InspectorName("Horn Lord")]
+        Male3 = 6,
+        [InspectorName("Soda")]
+        Male4 = 7,
+        [InspectorName("Polygon")]
+        Female5 = 8,
+        [InspectorName("Servant Of Babi")]
+        Male5 = 9,
+    }
+
+    [Serializable]
+    public enum TromboneSkin
+    {
+        [InspectorName("Do Not Override (Default)")]
+        DoNotOverride = -1,
+        [InspectorName("Brass")]
+        Brass = 0,
+        [InspectorName("Silver")]
+        Silver = 1,
+        [InspectorName("Red")]
+        Red = 2,
+        [InspectorName("Blue")]
+        Blue = 3,
+        [InspectorName("Green")]
+        Green = 4,
+        [InspectorName("Pink")]
+        Pink = 5,
+        [InspectorName("Polygon")]
+        Polygon = 6,
+        [InspectorName("Champ")]
+        Champ = 7,
+    }
+}

--- a/Helpers/Globals.cs
+++ b/Helpers/Globals.cs
@@ -1,6 +1,8 @@
-﻿using System.IO;
+﻿using BepInEx;
+using System.Collections.Generic;
+using System.IO;
+using TrombLoader.Data;
 using UnityEngine;
-using BepInEx;
 
 namespace TrombLoader.Helpers
 {
@@ -19,5 +21,7 @@ namespace TrombLoader.Helpers
         {
             return !File.Exists(Path.Combine(Application.dataPath, "StreamingAssets", "leveldata", $"{trackReference}.tmb"));
         }
+
+        public static List<Tromboner> Tromboners = new();
     }
 }


### PR DESCRIPTION
- Added the ability to put puppet instances in the Unity Project 
   - These puppets will automatically be hooked up and have the same behavior as the base game one
   - By default these use the player's puppet/trombone skins, but it can be overridden to create different looking puppets
   