### PR TITLE
don't crash if duplicate song

### DIFF
--- a/Class Patches/GameControllerStartPatch.cs
+++ b/Class Patches/GameControllerStartPatch.cs
@@ -556,7 +556,6 @@ namespace TrombLoader.Class_Patches
 
 					string jsonString = File.ReadAllText(customChartPath);
 					var jsonObject = JSON.Parse(jsonString);
-					Plugin.LogDebug(jsonObject.ToString());
 					customLevel.Deserialize(jsonObject);
 				}
 				__instance.bgdata.Clear();

--- a/Class Patches/LevelSelectControllerPatch.cs
+++ b/Class Patches/LevelSelectControllerPatch.cs
@@ -134,7 +134,6 @@ public class LevelSelectControllerPopulateScoresPatch
         for (int j = 2; j < 7; j++)
         {
             int score = int.Parse(vals[j]);
-            Debug.Log("test");
             list.Add(score > 0 ? score.ToString("n0") : "-");
         }
         for (int k = 0; k < 5; k++)

--- a/Class Patches/SaverLoaderPatch.cs
+++ b/Class Patches/SaverLoaderPatch.cs
@@ -62,7 +62,10 @@ namespace TrombLoader.Class_Patches
                     aux.Add(index.ToString());
 
                     fullTrackTitles.Add(aux.ToArray());
-                    Globals.ChartFolders.Add(customLevel.trackRef, songFolder);
+                    if (!Globals.ChartFolders.ContainsKey(customLevel.trackRef))
+                    {
+                        Globals.ChartFolders.Add(customLevel.trackRef, songFolder);
+                    }
                     index++;
                 }
                 else

--- a/Data/CustomSavedLevel.cs
+++ b/Data/CustomSavedLevel.cs
@@ -154,10 +154,8 @@ namespace TrombLoader.Data
 				}
 			}
 
-			Plugin.LogDebug("Deserializing Chart:");
 			foreach (JSONObject node in jsonObject["lyrics"].AsArray)
 			{
-				Plugin.LogDebug(node.ToString());
 				this.lyricstxt.Add(node["text"].ToString());
 				var aux = new List<float>();
 				aux.Add(node["bar"].AsFloat);

--- a/TrombLoader.csproj
+++ b/TrombLoader.csproj
@@ -78,4 +78,8 @@
 			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.VideoModule.dll</HintPath>
 		</Reference>
 	</ItemGroup>
+
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<Exec Command="copy $(TargetPath) &quot;$(TromboneChampDir)\BepInEx\plugins&quot;" />
+	</Target>
 </Project>


### PR DESCRIPTION
I'm unsure if you want to update to netstandard2.1, but `Dictionary.TryAdd` isn't available in netstandard2.0
- remove some noisier debug logs
- copy to bepinex folder on build