### PR TITLE
Set the maximum limit for beats to show to 64

### DIFF
--- a/Class Patches/GameControllerStartPatch.cs
+++ b/Class Patches/GameControllerStartPatch.cs
@@ -95,6 +95,8 @@ namespace TrombLoader.Class_Patches
 			__instance.scores_D = 0;
 			__instance.scores_F = 0;
 
+			__instance.beatstoshow = 64; // By default, this is 16.
+
 			if (GlobalVariables.scene_destination == "freeplay")
 			{
 				__instance.freeplay = true;

--- a/TrombLoader.csproj
+++ b/TrombLoader.csproj
@@ -7,7 +7,7 @@
 		<Version>1.4.0</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
-		<YourTromboneChampInstallationPath>D:\Games\SteamLibrary\steamapps\common\TromboneChamp</YourTromboneChampInstallationPath>
+		<YourTromboneChampInstallationPath>E:\SteamLibrary\steamapps\common\TromboneChamp</YourTromboneChampInstallationPath>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="Exists('..\..\TromboneChamp_Data')">


### PR DESCRIPTION
By default, the limit for the amount of beats that can show up at a time is 16. This pull request aims to increase that limit to a more reasonable amount of 64 notes. This would allow for charts like One Winged Angel to render all visible notes on screen.