### PR TITLE
Add support for decimal bpm

### DIFF
--- a/Class Patches/SaverLoaderPatch.cs
+++ b/Class Patches/SaverLoaderPatch.cs
@@ -62,7 +62,7 @@ namespace TrombLoader.Class_Patches
                         aux.Add(customLevel.description);
                         aux.Add(customLevel.difficulty.ToString());
                         aux.Add(Mathf.FloorToInt(customLevel.endpoint / (customLevel.tempo / 60f)).ToString());
-                        aux.Add(customLevel.tempo.ToString());
+                        aux.Add(Mathf.RoundToInt(customLevel.tempo).ToString());
                         aux.Add(index.ToString());
 
                         fullTrackTitles.Add(aux.ToArray());


### PR DESCRIPTION
# Motivation

The only issue we currently have with decimal BPM is that when the game goes to load the info displayed on the title screen, it expects the BPM to be reported as a string representing an int. Currently, if the BPM of a track is set to a float, we send it a string representing a float.

# Changes

- Before converting the BPM to a title data string, round it to the nearest int

# Testing

- Tested a tmb at 10 BPM, held a note for 18 seconds
- Tested the same tmb at 10.5 BPM, the same note lasts about 17.2 seconds