### PR TITLE
Add support for removing all lighting in a scene

### DIFF
--- a/Class Patches/GameControllerStartPatch.cs
+++ b/Class Patches/GameControllerStartPatch.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using SimpleJSON;
 using System.Collections;
 using System.IO;
@@ -316,6 +316,13 @@ namespace TrombLoader.Class_Patches
 						
 						var gameplayCam = GameObject.Find("GameplayCam")?.GetComponent<Camera>();
 						if (gameplayCam != null) gameplayCam.depth = 99;
+
+						var removeDefaultLights = gameObject.transform.Find("RemoveDefaultLights");
+						if (removeDefaultLights)
+						{
+							foreach (var light in GameObject.FindObjectsOfType<Light>()) light.enabled = false;
+							removeDefaultLights.gameObject.AddComponent<SceneLightingHelper>();
+						}
 					}
 				}
 			}

--- a/Helpers/SceneLightingHelper.cs
+++ b/Helpers/SceneLightingHelper.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace TrombLoader.Helpers;
 
-public class SceneLightingHelper:MonoBehaviour
+public class SceneLightingHelper : MonoBehaviour
 {
     public Color ambientSkyColor = Color.black;
     public Color ambientEquatorColor = Color.black;
@@ -17,7 +17,7 @@ public class SceneLightingHelper:MonoBehaviour
     public void Start()
     {
         RenderSettings.ambientSkyColor = ambientSkyColor;
-        RenderSettings.ambientEquatorColor = Color.black;
+        RenderSettings.ambientEquatorColor = ambientEquatorColor;
         //RenderSettings.ambientMode = AmbientMode.Flat;
         RenderSettings.ambientIntensity = ambientIntensity;
         RenderSettings.reflectionIntensity = reflectionIntensity;


### PR DESCRIPTION
# Motivation

It's currently impossible to remove all the lighting in a scene from existing trombackgrounds. This is because the default lighting has two components:

- A directional light
- Environmental lighting

Unfortunately, we can't just package `SceneLightingHelper.cs` with TrombLoaderBackgroundProject, since while that would get rid of the environmental lighting, it wouldn't be able to get rid of the lone directional light: Since everybody's `Start`s are called after the scene is loaded, custom lights would get removed by `SceneLightingHelper#Start`.

As a result, I propose this lighting removal flow: The background creator adds an empty GameObject named `RemoveDefaultLights` as the third or later of the camera's children. The rest of the flow is normal. If the version of TrombLoader has this patch, the default lighting will be removed by this code. On older versions, the default lights will just not be removed and that's fine.

# Changes

- When the trombackground loads, search for a direct child named `RemoveDefaultLights` and if it's found
  - Attach a `SceneLightingHelper` to it
  - Remove all existing lights in the scene

# Testing

- Created a trombackground with a `RemoveDefaultLights` and tested it: Lights removed successfully
- After playing a track without default lighting, play one with default lighting: Lights come back