### PR TITLE
Add shadows

### DIFF
--- a/Class Patches/GameControllerStartPatch.cs
+++ b/Class Patches/GameControllerStartPatch.cs
@@ -114,6 +114,7 @@ namespace TrombLoader.Class_Patches
 			__instance.ui_savebtn.onClick.AddListener(new UnityAction(__instance.tryToSaveLevel));
 			__instance.ui_loadbtn.onClick.AddListener(new UnityAction(__instance.loadFromEditor));
 			BloomModel.Settings settings = __instance.gameplayppp.bloom.settings;
+			QualitySettings.shadows = ShadowQuality.Disable;
 			settings.bloom.intensity = 0f;
 			__instance.gameplayppp.bloom.settings = settings;
 			if (!__instance.freeplay)
@@ -323,6 +324,9 @@ namespace TrombLoader.Class_Patches
 							foreach (var light in GameObject.FindObjectsOfType<Light>()) light.enabled = false;
 							removeDefaultLights.gameObject.AddComponent<SceneLightingHelper>();
 						}
+
+						var addShadows = gameObject.transform.Find("AddShadows");
+						if (addShadows) QualitySettings.shadows = ShadowQuality.All;
 					}
 				}
 			}

--- a/Class Patches/GameControllerStartPatch.cs
+++ b/Class Patches/GameControllerStartPatch.cs
@@ -114,7 +114,7 @@ namespace TrombLoader.Class_Patches
 			__instance.ui_savebtn.onClick.AddListener(new UnityAction(__instance.tryToSaveLevel));
 			__instance.ui_loadbtn.onClick.AddListener(new UnityAction(__instance.loadFromEditor));
 			BloomModel.Settings settings = __instance.gameplayppp.bloom.settings;
-			QualitySettings.shadows = ShadowQuality.Disable;
+			QualitySettings.shadows = ShadowQuality.Disable; // Default
 			settings.bloom.intensity = 0f;
 			__instance.gameplayppp.bloom.settings = settings;
 			if (!__instance.freeplay)
@@ -326,7 +326,11 @@ namespace TrombLoader.Class_Patches
 						}
 
 						var addShadows = gameObject.transform.Find("AddShadows");
-						if (addShadows) QualitySettings.shadows = ShadowQuality.All;
+						if (addShadows)
+						{
+							QualitySettings.shadows = ShadowQuality.All;
+							QualitySettings.shadowDistance = 100;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
# Motivation

By default, shadows are totally disabled. I wanted to keep this the case, but add the ability for trombackgrounds to enable them at will.

Since shadow settings are persistent, this means toggling them off, then checking if the trombackground wants to toggle them on.

I used the same technique for opting into shadows as opting out of the lighting system: An object after foreground and background named "AddShadows" will enable shadows.

# Changes

- Always flip shadows off at the same time that bloom is applied
- Check and flip shadows on at the same time lighting settings are applied.

# Testing

I created two test scenes, one with shadows and one without. They're otherwise identical, with a light that should cast a shadow on the scene with shadows enabled. On the scene with shadows disabled, the same setup should cast no light.

1. Check the scene with shadows disabled: no shadows appear
2. Check the scene with shadows enabled: shadows appear
3. Without closing the game, check the scene with shadows disabled again: no shadows appear