### PR TITLE
set notescoresaverage and samples to 0 on gamecontroller start

### DIFF
--- a/Class Patches/GameControllerStartPatch.cs
+++ b/Class Patches/GameControllerStartPatch.cs
@@ -82,8 +82,8 @@ namespace TrombLoader.Class_Patches
 				Cursor.lockState = CursorLockMode.Confined;
 			}
 			__instance.retrying = false;
-			__instance.notescoreaverage = -1f;
-			__instance.notescoresamples = 1f;
+			__instance.notescoreaverage = 0;
+			__instance.notescoresamples = 0;
 			__instance.curtains.SetActive(true);
 			__instance.curtainc = __instance.curtains.GetComponent<CurtainController>();
 			__instance.level_finshed = false;


### PR DESCRIPTION
Fixing a glitch in 1.0897+ where the first tap note of a map would be impossible to accuracy