### PR TITLE
Add NuGet packaging config & LICENSE

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0'
+      - run: dotnet build -c Release
+      - run: dotnet nuget push bin/Release/*.nupkg -k ${{ secrets.NUGET_TOKEN }} -s https://api.nuget.org/v3/index.json

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+﻿# The MIT License (MIT)
+
+Copyright © 2023 TrombLoader contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,5 @@ Launch Trombone Champ and enjoy your new custom songs!
 To get started making your own custom charts, check out the related [Midi2TromboneChamp](https://github.com/NyxTheShield/Midi2TromboneChamp) project for more.
 
 ## Developer Guide
-- Change YourTromboneChampInstallationPath in Trombloader.csproj
-- Download [NStrip](https://github.com/BepInEx/NStrip/releases/latest)
-- Make the game file methods public: `./NStrip -p <installation_location>/TromboneChamp_Data/Managed/Assembly.CSharp.dll`
+
 - Build: `dotnet build`

--- a/TrombLoader.csproj
+++ b/TrombLoader.csproj
@@ -3,10 +3,31 @@
         <TargetFramework>net472</TargetFramework>
         <AssemblyName>TrombLoader</AssemblyName>
         <Description>Trombone Champ Custom Chart Loader</Description>
-        <Version>2.0.0</Version>
+        <Version>2.0.0-rc.1</Version>
+        <BepInExPluginVersion>2.0.0</BepInExPluginVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
+        
+        <PackageId>TromboneChamp.TrombLoader</PackageId>
+        <Authors>NyxTheShield, legoandmars, offbeatwitch</Authors>
+        <Company>TromboneChamps</Company>
+        <PackageTags>Trombone Champ</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/NyxTheShield/TrombLoader</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <DefaultLanguage>en</DefaultLanguage>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(Configuration)' == 'Release'">
+        <None Include="$(SolutionDir)thunderstore\README.md" Pack="true" PackagePath="\" />
+        <None Include="$(SolutionDir)thunderstore\icon.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />


### PR DESCRIPTION
Since TootTally depends on us, we should publish to NuGet as a library - that way they don't have to mess around with vendored DLLs.

I've gone ahead and set up the NuGet package similarly to how I've done it over in BaboonAPI. I've also added a GitHub CI workflow that triggers on new tags - though it's untested. This will need a **`NUGET_TOKEN`** CI secret set before merging!

I've set the version to 2.0.0-rc.1 - my intent is to get this published as a release candidate so I can start updating TootTally.