### PR TITLE
Refactor CustomTrack

### DIFF
--- a/CustomTracks/CustomTrack.cs
+++ b/CustomTracks/CustomTrack.cs
@@ -1,117 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using BaboonAPI.Hooks.Tracks;
-using Newtonsoft.Json;
 using TrombLoader.CustomTracks.Backgrounds;
 using UnityEngine;
 
 namespace TrombLoader.CustomTracks;
 
-[Serializable]
 public class CustomTrack : TromboneTrack
 {
     /// <summary>
     ///  Folder path that this track can be found at
     /// </summary>
-    [JsonIgnore] public string folderPath { get; internal set; }
+    public string folderPath { get; }
 
-    [JsonIgnore] internal TrackLoader Loader { get; set; }
+    private readonly CustomTrackData _data;
+    private readonly TrackLoader _loader;
 
-    public string trackRef;
-    public string name;
-    public string shortName;
-    public string author;
-    public string description;
-    public float endpoint;
+    public string trackref => _data.trackRef;
+    public string trackname_long => _data.name;
+    public string trackname_short => _data.shortName;
+    public string year => _data.year.ToString();
+    public string artist => _data.author;
+    public string desc => _data.description;
+    public string genre => _data.genre;
+    public int difficulty => _data.difficulty;
+    public int tempo => (int) _data.tempo;
+    public int length => Mathf.FloorToInt(_data.endpoint / (_data.tempo / 60f));
 
-    [JsonProperty("year")] private int _year;
-    [JsonProperty("tempo")] private float _tempo;
-
-    public string genre { get; }
-    public int difficulty { get; }
-    public string backgroundMovement { get; }
-
-    // SavedLevel fields
-    public int savednotespacing { get; }
-    public int timesig { get; }
-    public List<Lyric> lyrics { get; }
-    public float[] note_color_start { get; }
-    public float[] note_color_end { get; }
-    public float[][] notes { get; }
-    public float[][] bgdata { get; }
-
-    [JsonIgnore] public string trackref => trackRef;
-    [JsonIgnore] public string trackname_long => name;
-    [JsonIgnore] public string trackname_short => shortName;
-    [JsonIgnore] public string year => _year.ToString();
-    [JsonIgnore] public string artist => author;
-    [JsonIgnore] public string desc => description;
-    [JsonIgnore] public int tempo => (int) _tempo;
-    [JsonIgnore] public int length => Mathf.FloorToInt(endpoint / (_tempo / 60f));
-
-    [JsonConstructor]
-    public CustomTrack(string trackRef, string name, string shortName, string author, string description, float endpoint,
-        int year, string genre, int difficulty, float tempo, string backgroundMovement, int savednotespacing, int timesig,
-        List<Lyric> lyrics, float[] note_color_start, float[] note_color_end, float[][] notes, float[][] bgdata)
+    public CustomTrack(string folderPath, CustomTrackData data, TrackLoader loader)
     {
-        this.trackRef = trackRef;
-        this.name = name;
-        this.shortName = shortName;
-        this.author = author;
-        this.description = description;
-        this.endpoint = endpoint;
-        this._year = year;
-        this.genre = genre;
-        this.difficulty = difficulty;
-        this._tempo = tempo;
-        this.backgroundMovement = backgroundMovement ?? "none";
-        this.savednotespacing = savednotespacing;
-        this.timesig = timesig;
-        this.lyrics = lyrics ?? new List<Lyric>();
-        this.note_color_start = note_color_start ?? new[] { 1.0f, 0.21f, 0f };
-        this.note_color_end = note_color_end ?? new[] { 1.0f, 0.8f, 0.3f };
-        this.notes = notes;
-        this.bgdata = bgdata ?? Array.Empty<float[]>();
-    }
-
-    [Serializable]
-    public class Lyric
-    {
-        public string text { get; }
-        public float bar { get; }
-
-        [JsonConstructor]
-        public Lyric(string text, float bar)
-        {
-            this.text = text;
-            this.bar = bar;
-        }
+        this.folderPath = folderPath;
+        _data = data;
+        _loader = loader;
     }
 
     public SavedLevel LoadChart()
     {
-        if (Loader?.ShouldReloadChart() == true)
-        {
-            return Loader.ReloadTrack(this);
-        }
-
-        var level = new SavedLevel
-        {
-            savedleveldata = new List<float[]>(notes),
-            bgdata = new List<float[]>(bgdata),
-            endpoint = endpoint,
-            lyricspos = lyrics.Select(lyric => new[] { lyric.bar, 0 }).ToList(),
-            lyricstxt = lyrics.Select(lyric => lyric.text).ToList(),
-            note_color_start = note_color_start,
-            note_color_end = note_color_end,
-            savednotespacing = savednotespacing,
-            tempo = _tempo,
-            timesig = timesig
-        };
-
-        return level;
+        return _loader?.ShouldReloadChart() == true ? _loader.ReloadTrack(this) : _data.ToSavedLevel();
     }
 
     public LoadedTromboneTrack LoadTrack()
@@ -126,7 +50,7 @@ public class CustomTrack : TromboneTrack
             var bundle = AssetBundle.LoadFromFile(Path.Combine(folderPath, "bg.trombackground"));
             return new CustomBackground(bundle, folderPath);
         }
-        
+
         var possibleVideoPath = Path.Combine(folderPath, "bg.mp4");
         if (File.Exists(possibleVideoPath))
         {
@@ -201,7 +125,7 @@ public class CustomTrack : TromboneTrack
             controller.tickontempo = false;
 
             // Apply background effect
-            controller.doBGEffect(_parent.backgroundMovement);
+            controller.doBGEffect(_parent._data.backgroundMovement);
         }
 
         public void Dispose()

--- a/CustomTracks/CustomTrack.cs
+++ b/CustomTracks/CustomTrack.cs
@@ -15,7 +15,9 @@ public class CustomTrack : TromboneTrack
     /// <summary>
     ///  Folder path that this track can be found at
     /// </summary>
-    [JsonIgnore] public string folderPath { get; set; }
+    [JsonIgnore] public string folderPath { get; internal set; }
+
+    [JsonIgnore] internal TrackLoader Loader { get; set; }
 
     public string trackRef;
     public string name;
@@ -90,6 +92,11 @@ public class CustomTrack : TromboneTrack
 
     public SavedLevel LoadChart()
     {
+        if (Loader?.ShouldReloadChart() == true)
+        {
+            return Loader.ReloadTrack(this);
+        }
+
         var level = new SavedLevel
         {
             savedleveldata = new List<float[]>(notes),

--- a/CustomTracks/CustomTrackData.cs
+++ b/CustomTracks/CustomTrackData.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace TrombLoader.CustomTracks;
+
+[JsonObject]
+public class CustomTrackData
+{
+    public string trackRef;
+    public string name;
+    public string shortName;
+    public string author;
+    public string description;
+    public float endpoint;
+    public int year;
+    public string genre;
+    public int difficulty;
+    public float tempo;
+    public string backgroundMovement;
+    public int savednotespacing;
+    public int timesig;
+    public List<Lyric> lyrics;
+    public float[] note_color_start;
+    public float[] note_color_end;
+    public float[][] notes;
+    public float[][] bgdata;
+
+    public SavedLevel ToSavedLevel()
+    {
+        return new SavedLevel
+        {
+            savedleveldata = new List<float[]>(notes),
+            bgdata = new List<float[]>(bgdata),
+            endpoint = endpoint,
+            lyricspos = lyrics.Select(lyric => new[] { lyric.bar, 0 }).ToList(),
+            lyricstxt = lyrics.Select(lyric => lyric.text).ToList(),
+            note_color_start = note_color_start,
+            note_color_end = note_color_end,
+            savednotespacing = savednotespacing,
+            tempo = tempo,
+            timesig = timesig
+        };
+    }
+
+    [JsonObject]
+    public class Lyric
+    {
+        public string text { get; }
+        public float bar { get; }
+
+        [JsonConstructor]
+        public Lyric(string text, float bar)
+        {
+            this.text = text;
+            this.bar = bar;
+        }
+    }
+}

--- a/CustomTracks/TrackLoader.cs
+++ b/CustomTracks/TrackLoader.cs
@@ -12,6 +12,23 @@ public class TrackLoader: TrackRegistrationEvent.Listener
 {
     private JsonSerializer _serializer = new();
 
+    public SavedLevel ReloadTrack(CustomTrack existing)
+    {
+        var chartPath = Path.Combine(existing.folderPath, Globals.defaultChartName);
+        using var stream = File.OpenText(chartPath);
+        using var reader = new JsonTextReader(stream);
+
+        var track = _serializer.Deserialize<CustomTrack>(reader);
+
+        // Avoid setting `track.Loader = this`, preventing a loop
+        return track?.LoadChart();
+    }
+
+    public bool ShouldReloadChart()
+    {
+        return Plugin.Instance.DeveloperMode.Value;
+    }
+
     public IEnumerable<TromboneTrack> OnRegisterTracks()
     {
         CreateMissingDirectories();
@@ -45,6 +62,7 @@ public class TrackLoader: TrackRegistrationEvent.Listener
             Plugin.LogDebug($"Found custom chart: {customLevel.trackref}");
 
             customLevel.folderPath = songFolder;
+            customLevel.Loader = this;
             yield return customLevel;
         }
     }

--- a/CustomTracks/TrackLoader.cs
+++ b/CustomTracks/TrackLoader.cs
@@ -20,6 +20,7 @@ public class TrackLoader: TrackRegistrationEvent.Listener
             .Concat(Directory.GetFiles(BepInEx.Paths.PluginPath, "song.tmb", SearchOption.AllDirectories))
             .Select(i => Path.GetDirectoryName(i));
 
+        var seen = new HashSet<string>();
         foreach (var songFolder in songs)
         {
             var chartPath = Path.Combine(songFolder, Globals.defaultChartName);
@@ -42,9 +43,17 @@ public class TrackLoader: TrackRegistrationEvent.Listener
 
             if (customLevel == null) continue;
 
-            Plugin.LogDebug($"Found custom chart: {customLevel.trackRef}");
+            if (seen.Add(customLevel.trackRef))
+            {
+                Plugin.LogDebug($"Found custom chart: {customLevel.trackRef}");
 
-            yield return new CustomTrack(songFolder, customLevel, this);
+                yield return new CustomTrack(songFolder, customLevel, this);
+            }
+            else
+            {
+                Plugin.LogWarning(
+                    $"Skipping folder {chartPath} as its trackref '{customLevel.trackRef}' was already loaded!");
+            }
         }
     }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -23,7 +23,9 @@ namespace TrombLoader
     {
         public static Plugin Instance;
         public ShaderHelper ShaderHelper;
+
         public ConfigEntry<int> beatsToShow;
+        public ConfigEntry<bool> DeveloperMode;
 
         private Harmony _harmony = new(PluginInfo.PLUGIN_GUID);
 
@@ -31,6 +33,8 @@ namespace TrombLoader
         {
             var customFile = new ConfigFile(Path.Combine(Paths.ConfigPath, "TrombLoader.cfg"), true);
             beatsToShow = customFile.Bind("General", "Note Display Limit", 64, "The maximum amount of notes displayed on screen at once.");
+            DeveloperMode = customFile.Bind("Charting", "Developer Mode", false,
+                "When enabled, TrombLoader will re-read chart data from disk each time a track is loaded.");
 
             Instance = this;
             LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -18,12 +18,13 @@ using UnityEngine.SceneManagement;
 namespace TrombLoader
 {
     [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+    [BepInDependency("ch.offbeatwit.baboonapi.plugin", "2.0.0")]
     public class Plugin : BaseUnityPlugin
     {
         public static Plugin Instance;
         public ShaderHelper ShaderHelper;
         public ConfigEntry<int> beatsToShow;
-        
+
         private Harmony _harmony = new(PluginInfo.PLUGIN_GUID);
 
         private void Awake()
@@ -53,7 +54,7 @@ namespace TrombLoader
             yield return www.SendWebRequest();
             while (!www.isDone)
                 yield return null;
-            
+
             if (www.isNetworkError || www.isHttpError)
             {
                 yield return www.error;


### PR DESCRIPTION
hmm today i will cause problems on purpose

So while implementing "developer mode", I wasn't really happy with the state of CustomTrack and decided to just go ahead and refactor it now. I think it's much nicer! And it means the "track reloading" can never accidentally get in an infinite loop.

Currently duplicate trackrefs cause BaboonAPI to "crash" (i.e. safely stop and show the crash screen). This is intended behaviour, because if you have multiple tracks with the same trackref, there's no good answer to "which one should load?". However, it's known that there are song packs out in the wild with cloned tracks nested in subfolders, so it's highly likely that users upgrading to TrombLoader 2 for the first time would first be greeted with a message telling them they have duplicate tracks, which is bad UX for the upgrade. So I've added checking on the TrombLoader side, because at least it can report the folder path of the duplicate track, where BaboonAPI can't.

- Add config option to reload charts from disk every play ("Developer Mode")
- Skip tracks with duplicate trackrefs during loading, currently printing a warning
  - In future, I would love to show a dialog box to the user telling them about this
- Add BepInDependency annotation to ensure correct load order

Once I've tested this works I will mark it ready for review & fix the conflicts