### PR TITLE
Point README to Trombone.Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,12 @@ Trombone Champ Custom Chart Loader
 This project is licensed under the terms of the MIT license.
 
 ## Installation
-Step 1: Install BepInEx
-Download [latest BepinEx release](https://github.com/BepInEx/BepInEx/releases/latest) and extract the contents of BepinEx_x64_VERSION.zip directly into the root of the Trombone Champ folder, IE C:\Program Files (x86)\Steam\steamapps\common\TromboneChamp\
 
-Step 2: Patch Trombone Champ with BepInEx
-Run the game once to install BepinEx properly.
-
-Step 3: Install the TrombLoader plugin
-Download the latest release from [Releases](https://github.com/NyxTheShield/TrombLoader/releases), and under the "assets" section, download `TrombLoader.dll` and put it into the `BepInEx/plugins` folder that was created in Step 2. IE: C:\Program Files (x86)\Steam\steamapps\common\TromboneChamp\BepInEx\plugins
-
-Step 4: Install custom songs
-Extract your custom songs to the CustomSongs folder in your Trombone Champ BepInEx folder. IE: C:\Program Files (x86)\Steam\steamapps\common\TromboneChamp\BepInEx\CustomSongs
-
-Step 5: Play your custom songs
-Launch Trombone Champ and enjoy your new custom songs!
+Installation instructions have been moved to [trombone.wiki](https://trombone.wiki/#/installing-r2modman), and uses [r2modman](https://github.com/ebkr/r2modmanPlus/releases/latest/) for mod management. Please follow the instructions there.
 
 ## Custom Charts
-To get started making your own custom charts, check out the related [Midi2TromboneChamp](https://github.com/NyxTheShield/Midi2TromboneChamp) project for more.
+To get started making your own custom charts, check out [trombone.wiki](https://trombone.wiki/#/creating-charts)'s tutorial on creating charts.
+Check out the related [Midi2TromboneChamp](https://github.com/NyxTheShield/Midi2TromboneChamp) project as well for more.
 
 ## Developer Guide
 


### PR DESCRIPTION
README.md should now be considered outdated as it points to manual BepInEx installation instead of trombone.wiki.

Thanks to [GappyV](https://www.twitch.tv/gappyv) for bringing this to my attention